### PR TITLE
修复添加物流地址信息后，返回物流地址列表后，无法显示新增的地址条目的问题。

### DIFF
--- a/pages/usercenter/address/list/index.js
+++ b/pages/usercenter/address/list/index.js
@@ -37,13 +37,9 @@ Page({
     }
   },
   addAddress() {
+    this.waitForNewAddress();
     wx.navigateTo({
       url: '/pages/usercenter/address/edit/index',
-    });
-  },
-  onEdit(e) {
-    wx.navigateTo({
-      url: `/pages/usercenter/address/edit/index?id=${e.detail.id}`,
     });
   },
   getAddressList() {


### PR DESCRIPTION
<!--
首先，感谢你的贡献！😄
请阅读并遵循 [TDesign 贡献指南](https://github.com/Tencent/tdesign/blob/main/docs/contributing.md)，填写以下 pull request 的信息。
PR 在维护者审核通过后会合并，谢谢！
-->

### 🤔 这个 PR 的性质是？

- [x] 日常 bug 修复
- [ ] 新特性提交
- [ ] 文档改进
- [ ] 演示代码改进
- [ ] 组件样式/交互改进
- [ ] CI/CD 改进
- [ ] 重构
- [ ] 代码风格优化
- [ ] 测试用例
- [ ] 分支合并
- [ ] 其他

### 🔗 相关 Issue

<!--
1. 描述相关需求的来源，如相关的 issue 讨论链接。
-->

### 💡 需求背景和解决方案

<!--
1. 要解决的具体问题。
2. 列出最终的 API 实现和用法。
3. 涉及UI/交互变动需要有截图或 GIF。
-->

* 修复添加物流地址信息后，返回物流地址列表后，无法显示新增的地址条目的问题。
* 删除可能无用的onEdit函数（实际已用editAddressHandle函数）

### 📝 更新日志

<!--
从用户角度描述具体变化，以及可能的 breaking change 和其他风险。
-->

- fix(物流地址页面): 添加物流地址信息后，返回物流地址列表后，无法显示新增的地址条目，需要用户从其他位置（如点击【用户中心】的【收货地址】菜单项）重新进入地址列表页面后才会刷新地址列表。

- [ ] 本条 PR 不需要纳入 Changelog

### ☑️ 请求合并前的自查清单

⚠️ 请自检并全部**勾选全部选项**。⚠️

- [x] 文档已补充或无须补充
- [x] 代码演示已提供或无须提供
- [x] TypeScript 定义已补充或无须补充
- [x] Changelog 已提供或无须提供
